### PR TITLE
Update ch2-06-2.md:pc初始化函数缺少return

### DIFF
--- a/ch2/ch2-06-2.md
+++ b/ch2/ch2-06-2.md
@@ -58,6 +58,7 @@ var pc [256]byte = func() (pc [256]byte) {
 	for i := range pc {
 		pc[i] = pc[i/2] + byte(i&1)
 	}
+	return
 }()
 ```
 


### PR DESCRIPTION
Update ch2-06-2.md
fix
```go
var pc [256]byte = func() (pc [256]byte) {
	for i := range pc {
		pc[i] = pc[i/2] + byte(i&1)
	}
}()
```
to
```go
var pc [256]byte = func() (pc [256]byte) {
	for i := range pc {
		pc[i] = pc[i/2] + byte(i&1)
	}
    return
}()
```
